### PR TITLE
Modifique el padding del input

### DIFF
--- a/src/styles/inputs.css
+++ b/src/styles/inputs.css
@@ -13,7 +13,7 @@ input {
   font-family: 'Montserrat', sans-serif;
   font-size: 1rem;
   outline: none;
-  padding: 0 1.5rem;
+  padding: 0 3.5rem 1.5rem;
   height: 100%;
   width: 100%;
   border-radius: 16px;


### PR DESCRIPTION
Agregue 3.5rem de pading al lado derecho para cuando este en teléfono movil no pase el texto por debajo del icono.PD:No se me ocurrió una mejor forma de probar esto de los cambios en otros repos jaajaj